### PR TITLE
Making types and functions required for Arrow conversion public

### DIFF
--- a/arrow_chunk.go
+++ b/arrow_chunk.go
@@ -21,7 +21,7 @@ type arrowResultChunk struct {
 	loc              *time.Location
 }
 
-func (arc *arrowResultChunk) decodeArrowChunk(rowType []execResponseRowType, highPrec bool) ([]chunkRowType, error) {
+func (arc *arrowResultChunk) decodeArrowChunk(rowType []ExecResponseRowType, highPrec bool) ([]chunkRowType, error) {
 	logger.Debug("Arrow Decoder")
 	var chunkRows []chunkRowType
 
@@ -38,14 +38,14 @@ func (arc *arrowResultChunk) decodeArrowChunk(rowType []execResponseRowType, hig
 		tmpRows := make([]chunkRowType, numRows)
 
 		for colIdx, col := range columns {
-			destcol := make([]snowflakeValue, numRows)
-			if err = arrowToValue(&destcol, rowType[colIdx], col, arc.loc, highPrec); err != nil {
+			destcol := make([]SnowflakeValue, numRows)
+			if err = ArrowToValue(&destcol, rowType[colIdx], col, arc.loc, highPrec); err != nil {
 				return nil, err
 			}
 
 			for rowIdx := 0; rowIdx < numRows; rowIdx++ {
 				if colIdx == 0 {
-					tmpRows[rowIdx] = chunkRowType{ArrowRow: make([]snowflakeValue, len(columns))}
+					tmpRows[rowIdx] = chunkRowType{ArrowRow: make([]SnowflakeValue, len(columns))}
 				}
 				tmpRows[rowIdx].ArrowRow[colIdx] = destcol[rowIdx]
 			}

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -32,7 +32,7 @@ type chunkDownloader interface {
 	reset()
 	getChunkMetas() []execResponseChunk
 	getQueryResultFormat() resultFormat
-	getRowType() []execResponseRowType
+	getRowType() []ExecResponseRowType
 	setNextChunkDownloader(downloader chunkDownloader)
 	getNextChunkDownloader() chunkDownloader
 	getArrowBatches() []*ArrowBatch
@@ -237,7 +237,7 @@ func (scd *snowflakeChunkDownloader) getNextChunkDownloader() chunkDownloader {
 	return scd.NextDownloader
 }
 
-func (scd *snowflakeChunkDownloader) getRowType() []execResponseRowType {
+func (scd *snowflakeChunkDownloader) getRowType() []ExecResponseRowType {
 	return scd.RowSet.RowType
 }
 
@@ -569,7 +569,7 @@ func (scd *streamChunkDownloader) getNextChunkDownloader() chunkDownloader {
 	return scd.NextDownloader
 }
 
-func (scd *streamChunkDownloader) getRowType() []execResponseRowType {
+func (scd *streamChunkDownloader) getRowType() []ExecResponseRowType {
 	return scd.RowSet.RowType
 }
 
@@ -602,7 +602,7 @@ func newStreamChunkDownloader(
 	ctx context.Context,
 	fetcher streamChunkFetcher,
 	total int64,
-	rowType []execResponseRowType,
+	rowType []ExecResponseRowType,
 	firstRows [][]*string,
 	chunks []execResponseChunk) *streamChunkDownloader {
 	return &streamChunkDownloader{

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -189,7 +189,7 @@ func TestStreamChunkDownloaderFirstRows(t *testing.T) {
 		context.Background(),
 		fetcher,
 		int64(len(firstRows)),
-		[]execResponseRowType{},
+		[]ExecResponseRowType{},
 		firstRows,
 		[]execResponseChunk{})
 	if err := downloader.start(); err != nil {
@@ -231,7 +231,7 @@ func TestStreamChunkDownloaderChunks(t *testing.T) {
 		context.Background(),
 		fetcher,
 		int64(len(firstRows)),
-		[]execResponseRowType{},
+		[]ExecResponseRowType{},
 		firstRows,
 		responseChunks)
 	if err := downloader.start(); err != nil {

--- a/converter.go
+++ b/converter.go
@@ -296,7 +296,7 @@ func decimalToBigFloat(num decimal128.Num, scale int64) *big.Float {
 	return new(big.Float).Quo(f, s)
 }
 
-// Arrow Interface (Column) converter. This is called when Arrow chunks are
+// ArrowToValue is Arrow Interface (Column) converter. This is called when Arrow chunks are
 // downloaded to convert to the corresponding row type.
 func ArrowToValue(
 	destcol *[]SnowflakeValue,

--- a/converter.go
+++ b/converter.go
@@ -188,7 +188,7 @@ func extractTimestamp(srcValue *string) (sec int64, nsec int64, err error) {
 // This is mainly used in fetching data.
 func stringToValue(
 	dest *driver.Value,
-	srcColumnMeta execResponseRowType,
+	srcColumnMeta ExecResponseRowType,
 	srcValue *string,
 	loc *time.Location) error {
 	if srcValue == nil {
@@ -298,9 +298,9 @@ func decimalToBigFloat(num decimal128.Num, scale int64) *big.Float {
 
 // Arrow Interface (Column) converter. This is called when Arrow chunks are
 // downloaded to convert to the corresponding row type.
-func arrowToValue(
-	destcol *[]snowflakeValue,
-	srcColumnMeta execResponseRowType,
+func ArrowToValue(
+	destcol *[]SnowflakeValue,
+	srcColumnMeta ExecResponseRowType,
 	srcValue array.Interface,
 	loc *time.Location,
 	higherPrecision bool) error {
@@ -762,7 +762,7 @@ func higherPrecisionEnabled(ctx context.Context) bool {
 	return ok && d
 }
 
-func arrowToRecord(record array.Record, rowType []execResponseRowType, loc *time.Location) (array.Record, error) {
+func arrowToRecord(record array.Record, rowType []ExecResponseRowType, loc *time.Location) (array.Record, error) {
 	s, err := recordToSchema(record.Schema(), rowType, loc)
 	if err != nil {
 		return nil, err
@@ -974,7 +974,7 @@ func arrowToRecord(record array.Record, rowType []execResponseRowType, loc *time
 	return array.NewRecord(s, cols, numRows), nil
 }
 
-func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.Location) (*arrow.Schema, error) {
+func recordToSchema(sc *arrow.Schema, rowType []ExecResponseRowType, loc *time.Location) (*arrow.Schema, error) {
 	var fields []arrow.Field
 	for i := 0; i < len(sc.Fields()); i++ {
 		f := sc.Field(i)

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -1090,7 +1090,7 @@ func (sfa *snowflakeFileTransferAgent) result() (*execResponse, error) {
 			cc := make([]chunkRowType, len(ccrs))
 			populateJSONRowSet(cc, ccrs)
 			data.QueryResultFormat = "json"
-			rt := []execResponseRowType{
+			rt := []ExecResponseRowType{
 				{Name: "source", ByteLength: 10000, Length: 10000, Type: "TEXT", Scale: 0, Nullable: false},
 				{Name: "target", ByteLength: 10000, Length: 10000, Type: "TEXT", Scale: 0, Nullable: false},
 				{Name: "source_size", ByteLength: 64, Length: 64, Type: "FIXED", Scale: 0, Nullable: false},
@@ -1144,7 +1144,7 @@ func (sfa *snowflakeFileTransferAgent) result() (*execResponse, error) {
 			cc := make([]chunkRowType, len(ccrs))
 			populateJSONRowSet(cc, ccrs)
 			data.QueryResultFormat = "json"
-			rt := []execResponseRowType{
+			rt := []ExecResponseRowType{
 				{Name: "file", ByteLength: 10000, Length: 10000, Type: "TEXT", Scale: 0, Nullable: false},
 				{Name: "size", ByteLength: 64, Length: 64, Type: "FIXED", Scale: 0, Nullable: false},
 				{Name: "status", ByteLength: 10000, Length: 10000, Type: "TEXT", Scale: 0, Nullable: false},

--- a/query.go
+++ b/query.go
@@ -29,7 +29,7 @@ type execRequest struct {
 	BindStage    string                       `json:"bindStage,omitempty"`
 }
 
-type execResponseRowType struct {
+type ExecResponseRowType struct {
 	Name       string `json:"name"`
 	ByteLength int64  `json:"byteLength"`
 	Length     int64  `json:"length"`
@@ -72,7 +72,7 @@ type execResponseStageInfo struct {
 type execResponseData struct {
 	// succeed query response data
 	Parameters         []nameValueParameter  `json:"parameters,omitempty"`
-	RowType            []execResponseRowType `json:"rowtype,omitempty"`
+	RowType            []ExecResponseRowType `json:"rowtype,omitempty"`
 	RowSet             [][]*string           `json:"rowset,omitempty"`
 	RowSetBase64       string                `json:"rowsetbase64,omitempty"`
 	Total              int64                 `json:"total,omitempty"`    // java:long

--- a/query.go
+++ b/query.go
@@ -29,6 +29,7 @@ type execRequest struct {
 	BindStage    string                       `json:"bindStage,omitempty"`
 }
 
+// ExecResponseRowType holds type metadata for a response column
 type ExecResponseRowType struct {
 	Name       string `json:"name"`
 	ByteLength int64  `json:"byteLength"`

--- a/result.go
+++ b/result.go
@@ -18,6 +18,7 @@ type SnowflakeResult interface {
 	GetQueryID() string
 	GetStatus() queryStatus
 	GetArrowBatches() ([]*ArrowBatch, error)
+	GetRowType() ([]ExecResponseRowType, error)
 }
 
 type snowflakeResult struct {
@@ -52,6 +53,13 @@ func (res *snowflakeResult) GetStatus() queryStatus {
 }
 
 func (res *snowflakeResult) GetArrowBatches() ([]*ArrowBatch, error) {
+	return nil, &SnowflakeError{
+		Number:  ErrNotImplemented,
+		Message: errMsgNotImplemented,
+	}
+}
+
+func (res *snowflakeResult) GetRowType() ([]ExecResponseRowType, error) {
 	return nil, &SnowflakeError{
 		Number:  ErrNotImplemented,
 		Message: errMsgNotImplemented,

--- a/rows.go
+++ b/rows.go
@@ -38,15 +38,15 @@ type snowflakeRows struct {
 	errChannel          chan error
 }
 
-type snowflakeValue interface{}
+type SnowflakeValue interface{}
 
 type chunkRowType struct {
 	RowSet   []*string
-	ArrowRow []snowflakeValue
+	ArrowRow []SnowflakeValue
 }
 
 type rowSetType struct {
-	RowType      []execResponseRowType
+	RowType      []ExecResponseRowType
 	JSON         [][]*string
 	RowSetBase64 string
 }
@@ -148,6 +148,10 @@ func (rows *snowflakeRows) GetStatus() queryStatus {
 // GetArrowBatches returns an array of ArrowBatch objects to retrieve data in array.Record format
 func (rows *snowflakeRows) GetArrowBatches() ([]*ArrowBatch, error) {
 	return rows.ChunkDownloader.getArrowBatches(), nil
+}
+
+func (rows *snowflakeRows) GetRowType() ([]ExecResponseRowType, error) {
+	return rows.ChunkDownloader.getRowType(), nil
 }
 
 func (rows *snowflakeRows) Next(dest []driver.Value) (err error) {

--- a/rows.go
+++ b/rows.go
@@ -38,6 +38,7 @@ type snowflakeRows struct {
 	errChannel          chan error
 }
 
+// SnowflakeValue is a generic value
 type SnowflakeValue interface{}
 
 type chunkRowType struct {
@@ -150,6 +151,7 @@ func (rows *snowflakeRows) GetArrowBatches() ([]*ArrowBatch, error) {
 	return rows.ChunkDownloader.getArrowBatches(), nil
 }
 
+// GetRowType returns an array of response column metadata objects
 func (rows *snowflakeRows) GetRowType() ([]ExecResponseRowType, error) {
 	return rows.ChunkDownloader.getRowType(), nil
 }

--- a/rows_test.go
+++ b/rows_test.go
@@ -98,7 +98,7 @@ func TestRowsWithoutChunkDownloader(t *testing.T) {
 	for i = 0; i < 10; i++ {
 		cc = append(cc, []*string{&sts1, &sts2})
 	}
-	rt := []execResponseRowType{
+	rt := []ExecResponseRowType{
 		{Name: "c1", ByteLength: 10, Length: 10, Type: "FIXED", Scale: 0, Nullable: true},
 		{Name: "c2", ByteLength: 100000, Length: 100000, Type: "TEXT", Scale: 0, Nullable: false},
 	}
@@ -164,7 +164,7 @@ func TestRowsWithChunkDownloader(t *testing.T) {
 		v2 := fmt.Sprintf("Test%v", i)
 		cc = append(cc, []*string{&v1, &v2})
 	}
-	rt := []execResponseRowType{
+	rt := []ExecResponseRowType{
 		{Name: "c1", ByteLength: 10, Length: 10, Type: "FIXED", Scale: 0, Nullable: true},
 		{Name: "c2", ByteLength: 100000, Length: 100000, Type: "TEXT", Scale: 0, Nullable: false},
 	}
@@ -243,7 +243,7 @@ func TestRowsWithChunkDownloaderError(t *testing.T) {
 		v2 := fmt.Sprintf("Test%v", i)
 		cc = append(cc, []*string{&v1, &v2})
 	}
-	rt := []execResponseRowType{
+	rt := []ExecResponseRowType{
 		{Name: "c1", ByteLength: 10, Length: 10, Type: "FIXED", Scale: 0, Nullable: true},
 		{Name: "c2", ByteLength: 100000, Length: 100000, Type: "TEXT", Scale: 0, Nullable: false},
 	}
@@ -321,7 +321,7 @@ func TestRowsWithChunkDownloaderErrorFail(t *testing.T) {
 		v2 := fmt.Sprintf("Test%v", i)
 		cc = append(cc, []*string{&v1, &v2})
 	}
-	rt := []execResponseRowType{
+	rt := []ExecResponseRowType{
 		{Name: "c1", ByteLength: 10, Length: 10, Type: "FIXED", Scale: 0, Nullable: true},
 		{Name: "c2", ByteLength: 100000, Length: 100000, Type: "TEXT", Scale: 0, Nullable: false},
 	}


### PR DESCRIPTION
The default rows API's memory footprint does not scale well with query result size, since the entire result set is held in memory.

We found that using the `gosnowflake.WithArrowBatches()` API can help with that, but then query results are provided in the Apache Arrow format which requires additional effort to decode. All Arrow decoding code in this library is private and therefore cannot be currently reused.

This PR makes types and functions required for Arrow conversion public to allow code reuse.

It's not intended to be merged into the upstream repository in this form.